### PR TITLE
tonic-rpc-macro: Use `CodeGenBuilder` instead of `generate` functions

### DIFF
--- a/tonic-rpc-macro/Cargo.toml
+++ b/tonic-rpc-macro/Cargo.toml
@@ -19,6 +19,6 @@ proc-macro = true
 heck = "0.4"
 itertools = "0.10"
 syn = { version = "1.0", features = ["full"] }
-tonic-build = "0.8"
+tonic-build = "0.8.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/tonic-rpc-macro/src/lib.rs
+++ b/tonic-rpc-macro/src/lib.rs
@@ -4,7 +4,7 @@ use syn::{
     parse_macro_input, punctuated::Pair, FnArg, ItemTrait, ReturnType, TraitItem, TraitItemMethod,
     Type,
 };
-use tonic_build::{Attributes, Method, Service};
+use tonic_build::{Method, Service};
 
 struct RustDefMethod {
     pub name: String,
@@ -248,8 +248,14 @@ where
         name,
         methods,
     };
-    let client = tonic_build::client::generate(&service, false, "", false, &Attributes::default());
-    let server = tonic_build::server::generate(&service, false, "", false, &Attributes::default());
+    let client = tonic_build::CodeGenBuilder::new()
+        .compile_well_known_types(false)
+        .emit_package(false)
+        .generate_client(&service, "");
+    let server = tonic_build::CodeGenBuilder::new()
+        .compile_well_known_types(false)
+        .emit_package(false)
+        .generate_server(&service, "");
     let types = service.methods.iter().map(|m| {
         let request_name = m.generated_request();
         let response_name = m.generated_response();

--- a/tonic-rpc/Cargo.toml
+++ b/tonic-rpc/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.4", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = [ "net" ] }
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.8.4"
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]


### PR DESCRIPTION
Since tonic 0.8.3 (specifically hyperium/tonic#1130), builds of tonic-rpc-macro fail due to a change in the `tonic_build::{client, server}::generate` functions. As those functions have been deprecated as of 0.8.4, updating the two lines in `make_rpc` to use `CodeGenBuilder` seemed like the better route.